### PR TITLE
Add support for unicode escape sequences inside stream-based storages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,13 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
+  - 7.2
   - nightly
 
 matrix:
   allow_failures:
     - php: nightly
+    - php: hhvm
 
 before_script:
   - curl -sSL https://dl.bintray.com/xp-runners/generic/xp-run-master.sh > xp-run

--- a/src/main/php/security/credentials/FromStream.class.php
+++ b/src/main/php/security/credentials/FromStream.class.php
@@ -21,7 +21,11 @@ class FromStream implements Secrets {
     $this->secrets= [];
     foreach (new LinesIn($this->input) as $line) {
       sscanf($line, '%[^=]=%s', $name, $secret);
-      $this->secrets[strtolower($name)]= new Secret($secret);
+      $this->secrets[strtolower($name)]= new Secret(preg_replace_callback(
+        '/\\\\u\{([0-9a-f]+)\}/i',
+        function($matches) { return iconv('utf-16be', 'utf-8', pack('H*', $matches[1])); },
+        $secret
+      ));
     }
   }
 

--- a/src/test/php/security/credentials/unittest/FromFileTest.class.php
+++ b/src/test/php/security/credentials/unittest/FromFileTest.class.php
@@ -14,7 +14,8 @@ class FromFileTest extends AbstractSecretsTest {
       "TEST_DB_PASSWORD=db\n".
       "TEST_LDAP_PASSWORD=ldap\n".
       "PROD_MASTER_KEY=master\n".
-      "XP/APP/MYSQL=test"
+      "XP/APP/MYSQL=test\n".
+      "CLOUD_SECRET=!\\u{0007}nicode"
     )));
   }
 
@@ -42,5 +43,10 @@ class FromFileTest extends AbstractSecretsTest {
     $fixture->open();
     $fixture->close();
     $this->assertFalse($file->exists());
+  }
+
+  #[@test]
+  public function unicode_escape_sequences() {
+    $this->assertCredential("!\x07nicode", 'cloud_secret');
   }
 }


### PR DESCRIPTION
Example (inserts the bytes for the 😂 emoji)

```
SMILEY=\u{1F602}
```

See https://wiki.php.net/rfc/unicode_escape