### PR TITLE
Byte escape sequences

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,13 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
+  - 7.2
   - nightly
 
 matrix:
   allow_failures:
     - php: nightly
+    - php: hhvm
 
 before_script:
   - curl -sSL https://dl.bintray.com/xp-runners/generic/xp-run-master.sh > xp-run

--- a/src/main/php/security/credentials/FromStream.class.php
+++ b/src/main/php/security/credentials/FromStream.class.php
@@ -21,7 +21,11 @@ class FromStream implements Secrets {
     $this->secrets= [];
     foreach (new LinesIn($this->input) as $line) {
       sscanf($line, '%[^=]=%s', $name, $secret);
-      $this->secrets[strtolower($name)]= new Secret($secret);
+      $this->secrets[strtolower($name)]= new Secret(preg_replace_callback(
+        '/\\\\x([0-9a-f]{2})/i',
+        function($matches) { return pack('H*', $matches[1]); },
+        $secret
+      ));
     }
   }
 

--- a/src/test/php/security/credentials/unittest/FromFileTest.class.php
+++ b/src/test/php/security/credentials/unittest/FromFileTest.class.php
@@ -14,7 +14,8 @@ class FromFileTest extends AbstractSecretsTest {
       "TEST_DB_PASSWORD=db\n".
       "TEST_LDAP_PASSWORD=ldap\n".
       "PROD_MASTER_KEY=master\n".
-      "XP/APP/MYSQL=test"
+      "XP/APP/MYSQL=test\n".
+      "CLOUD_SECRET=S\\xa7T"
     )));
   }
 
@@ -42,5 +43,10 @@ class FromFileTest extends AbstractSecretsTest {
     $fixture->open();
     $fixture->close();
     $this->assertFalse($file->exists());
+  }
+
+  #[@test]
+  public function byte_escape_sequence() {
+    $this->assertCredential("S\xa7T", 'cloud_secret');
   }
 }


### PR DESCRIPTION
Add support for byte escape sequences inside stream-based storages

Example:

```
PASSWORD=\xa7uperCool
```

*(These are the same hex escape sequences as working in double quoted strings)*