### PR TITLE
Lazily open secret stores

### DIFF
--- a/src/main/php/security/credentials/Credentials.class.php
+++ b/src/main/php/security/credentials/Credentials.class.php
@@ -1,13 +1,15 @@
 <?php namespace security\credentials;
 
+use lang\Closeable;
 use lang\ElementNotFoundException;
 use lang\IllegalArgumentException;
 
-class Credentials implements \lang\Closeable {
+class Credentials implements Closeable {
   private $secrets;
   private $open= false;
 
   /**
+   * Creates a new credential store
    *
    * @param  security.credentials.Secrets... $secrets
    * @throws lang.IllegalArgumentException
@@ -43,8 +45,8 @@ class Credentials implements \lang\Closeable {
    * @throws lang.ElementNotFoundException
    */
   public function named($name) {
-    foreach ($this->open()->secrets as $secrets) {
-      if (null !== ($secret= $secrets->named($name))) return $secret;
+    foreach ($this->secrets as $secrets) {
+      if (null !== ($secret= $secrets->open()->named($name))) return $secret;
     }
     throw new ElementNotFoundException('No credential named "'.$name.'"');
   }
@@ -56,7 +58,7 @@ class Credentials implements \lang\Closeable {
    * @return php.Generator
    */
   public function all($pattern) {
-    foreach ($this->open()->secrets as $secrets) {
+    foreach ($this->secrets as $secrets) {
       foreach ($secrets->all($pattern) as $name => $secret) {
         yield $name => $secret;
       }
@@ -69,12 +71,10 @@ class Credentials implements \lang\Closeable {
    * @return self
    */
   public function close() {
-    if ($this->open) {
-      foreach ($this->secrets as $secrets) {
-        $secrets->close();
-      }
-      $this->open= false;
-    }    
+    foreach ($this->secrets as $secrets) {
+      $secrets->close();
+    }
+    $this->open= false;
   }
 
   /** @return void */

--- a/src/main/php/security/credentials/FromDockerSecrets.class.php
+++ b/src/main/php/security/credentials/FromDockerSecrets.class.php
@@ -1,8 +1,8 @@
 <?php namespace security\credentials;
 
 use io\File;
-use io\Path;
 use io\Folder;
+use io\Path;
 use util\Secret;
 
 /**
@@ -36,7 +36,8 @@ class FromDockerSecrets implements Secrets {
   /** @return io.Path */
   public function path() { return $this->path; }
 
-  public function open() { }
+  /** @return self */
+  public function open() { return $this; }
 
   /**
    * Get a named credential
@@ -75,5 +76,6 @@ class FromDockerSecrets implements Secrets {
     }
   }
 
+  /** @return void */
   public function close() { }
 }

--- a/src/main/php/security/credentials/FromEnvironment.class.php
+++ b/src/main/php/security/credentials/FromEnvironment.class.php
@@ -18,8 +18,8 @@ class FromEnvironment implements Secrets {
     $this->remove= $remove;
   }
 
-  /** @return void */
-  public function open() { }
+  /** @return self */
+  public function open() { return $this; }
 
   /**
    * Get a named credential
@@ -50,6 +50,9 @@ class FromEnvironment implements Secrets {
 
   /** @return void */
   public function close() {
-    Environment::export($this->unset);
+    if ($this->unset) {
+      Environment::export($this->unset);
+      $this->unset= [];
+    }
   }
 }

--- a/src/main/php/security/credentials/FromKeePass.class.php
+++ b/src/main/php/security/credentials/FromKeePass.class.php
@@ -2,25 +2,30 @@
 
 use info\keepass\KeePassDatabase;
 use info\keepass\Key;
-use util\Secret;
 use io\File;
+use util\Secret;
 
 class FromKeePass implements Secrets {
+  private $file, $key;
+  private $db= null;
 
   /**
    * Uses KeePass database for storage
    *
    * @param  io.File|string $file
-   * @param  util.Secrert $key
+   * @param  util.Secret $key
    */
   public function __construct($file, Secret $key) {
     $this->file= $file instanceof File ? $file : new File($file);
     $this->key= $key;
   }
 
-  /** @return void */
+  /** @return self */
   public function open() {
-    $this->db= KeePassDatabase::open($this->file->in(), new Key($this->key->reveal()));
+    if (null === $this->db) {
+      $this->db= KeePassDatabase::open($this->file->in(), new Key($this->key->reveal()));
+    }
+    return $this;
   }
 
   /**
@@ -66,6 +71,9 @@ class FromKeePass implements Secrets {
 
   /** @return void */
   public function close() {
-    $this->db->close();
+    if ($this->db) {
+      $this->db->close();
+      $this->db= null;
+    }
   }
 }

--- a/src/main/php/security/credentials/FromStream.class.php
+++ b/src/main/php/security/credentials/FromStream.class.php
@@ -16,17 +16,20 @@ class FromStream implements Secrets {
     $this->input= cast($input, 'io.streams.TextReader|io.streams.InputStream|io.Channel|string');
   }
 
-  /** @return void */
+  /** @return self */
   public function open() {
-    $this->secrets= [];
-    foreach (new LinesIn($this->input) as $line) {
-      sscanf($line, '%[^=]=%s', $name, $secret);
-      $this->secrets[strtolower($name)]= new Secret(preg_replace_callback(
-        '/\\\\x([0-9a-f]{2})/i',
-        function($matches) { return pack('H*', $matches[1]); },
-        $secret
-      ));
+    if (null === $this->secrets) {
+      $this->secrets= [];
+      foreach (new LinesIn($this->input) as $line) {
+        sscanf($line, '%[^=]=%s', $name, $secret);
+        $this->secrets[strtolower($name)]= new Secret(preg_replace_callback(
+          '/\\\\x([0-9a-f]{2})/i',
+          function($matches) { return pack('H*', $matches[1]); },
+          $secret
+        ));
+      }
     }
+    return $this;
   }
 
   /**

--- a/src/main/php/security/credentials/FromVault.class.php
+++ b/src/main/php/security/credentials/FromVault.class.php
@@ -1,7 +1,7 @@
 <?php namespace security\credentials;
 
-use webservices\rest\Endpoint;
 use util\Secret;
+use webservices\rest\Endpoint;
 
 class FromVault implements Secrets {
   private $endpoint;
@@ -24,10 +24,8 @@ class FromVault implements Secrets {
     }
   }
 
-  /** @return void */
-  public function open() {
-    // NOOP
-  }
+  /** @return self */
+  public function open() { return $this; }
 
   /**
    * Get a named credential

--- a/src/main/php/security/credentials/Secrets.class.php
+++ b/src/main/php/security/credentials/Secrets.class.php
@@ -2,6 +2,7 @@
 
 interface Secrets {
 
+  /** @return self */
   public function open();
 
   /**
@@ -20,5 +21,6 @@ interface Secrets {
    */
   public function all($pattern);
 
+  /** @return void */
   public function close();
 }

--- a/src/test/php/security/credentials/unittest/AbstractSecretsTest.class.php
+++ b/src/test/php/security/credentials/unittest/AbstractSecretsTest.class.php
@@ -23,6 +23,16 @@ abstract class AbstractSecretsTest extends \unittest\TestCase {
     }
   }
 
+  #[@test]
+  public function open_and_close_can_be_called_twice() {
+    $fixture= $this->newFixture();
+    $fixture->open();
+    $fixture->open();
+
+    $fixture->close();
+    $fixture->close();
+  }
+
   /**
    * Assertion helper
    *


### PR DESCRIPTION
This pull request changes the `Credentials` API to lazily open secret stores:

```php
$credentials= new Credentials(new FromEnvironment(), new FromFile($file));

// Doesn't open file if LDAP_PASS exists in environment
$pass= $credentials->named('ldap-pass');
```