### PR TITLE
Add Credentials::expanding() to add expansion in property files

### DIFF
--- a/src/main/php/security/credentials/Credentials.class.php
+++ b/src/main/php/security/credentials/Credentials.class.php
@@ -1,9 +1,11 @@
 <?php namespace security\credentials;
 
+use lang\Closeable;
 use lang\ElementNotFoundException;
 use lang\IllegalArgumentException;
+use util\PropertyAccess;
 
-class Credentials implements \lang\Closeable {
+class Credentials implements Closeable {
   private $secrets;
   private $open= false;
 
@@ -18,6 +20,16 @@ class Credentials implements \lang\Closeable {
     }
 
     $this->secrets= cast($secrets, 'security.credentials.Secrets[]');
+  }
+
+  /**
+   * Expand credentials inside a given properties file
+   *
+   * @param  util.PropertyAccess $prop
+   * @param  util.PropertyAccess
+   */
+  public function expanding(PropertyAccess $prop) {
+    return $prop->expanding('secret', function($name) { return $this->named($name)->reveal(); });
   }
 
   /**

--- a/src/test/php/security/credentials/unittest/PropertiesTest.class.php
+++ b/src/test/php/security/credentials/unittest/PropertiesTest.class.php
@@ -1,0 +1,27 @@
+<?php namespace security\credentials\unittest;
+
+use io\streams\MemoryInputStream;
+use security\credentials\Credentials;
+use security\credentials\Secrets;
+use unittest\TestCase;
+use util\Properties;
+use util\Secret;
+
+class PropertiesTest extends TestCase {
+
+  #[@test]
+  public function expanding() {
+    $secret= new Secret('Expanded!');
+    $credentials= new Credentials(newinstance(Secrets::class, [], [
+      'open'  => function() { },
+      'named' => function($name) use($secret) { return $secret; },
+      'all'   => function($pattern) { },
+      'close' => function() { }
+    ]));
+
+    $prop= $credentials->expanding(new Properties());
+    $prop->load(new MemoryInputStream('pass=${secret.test}'));
+
+    $this->assertEquals($secret->reveal(), $prop->readString(null, 'pass'));
+  }
+}


### PR DESCRIPTION
```php
$credentials= new Credentials(new FromEnvironment(), new FromFile('credentials'));

// Before
$config= $environment->properties('inject')->expanding(
  'secret',
  function($name) { return $credentials->named($name)->reveal(); }
);

// After
$config= $credentials->expanding($environment->properties('inject'));
```